### PR TITLE
CombineConfigures is redundant with + for delegates

### DIFF
--- a/src/Tmds.ExecFunction/FunctionExecutor.cs
+++ b/src/Tmds.ExecFunction/FunctionExecutor.cs
@@ -18,88 +18,75 @@ namespace Tmds.Utils
         }
 
         public Process Start(Action action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, _configure + configure);
 
         public Process Start(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, args, _configure + configure);
 
         public Process Start(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, _configure + configure);
 
         public Process Start(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, args, _configure + configure);
 
         public Process Start(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, _configure + configure);
 
         public Process Start(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, args, _configure + configure);
 
         public Process Start(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, _configure + configure);
 
         public Process Start(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Start(action, args, _configure + configure);
 
         public void Run(Action action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, _configure + configure);
 
         public void Run(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, args, _configure + configure);
 
         public void Run(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, _configure + configure);
 
         public void Run(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, args, _configure + configure);
 
         public void Run(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, _configure + configure);
 
         public void Run(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, args, _configure + configure);
 
         public void Run(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, _configure + configure);
 
         public void Run(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.Run(action, args, _configure + configure);
 
         public Task RunAsync(Action action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, _configure + configure);
 
         public Task RunAsync(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, args, _configure + configure);
 
         public Task RunAsync(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, _configure + configure);
 
         public Task RunAsync(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, args, _configure + configure);
 
         public Task RunAsync(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, _configure + configure);
 
         public Task RunAsync(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, args, _configure + configure);
 
         public Task RunAsync(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, CombineConfigures(_configure, configure));
+            => ExecFunction.RunAsync(action, _configure + configure);
 
         public Task RunAsync(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, CombineConfigures(_configure, configure));
-
-        private static Action<ExecFunctionOptions> CombineConfigures(Action<ExecFunctionOptions> first, Action<ExecFunctionOptions> second)
-        {
-            if (first == null)
-            {
-                return second;
-            }
-            if (second == null)
-            {
-                return first;
-            }
-            return psi => { first.Invoke(psi); second.Invoke(psi); };
-        }
+            => ExecFunction.RunAsync(action, args, _configure + configure);
     }
 }


### PR DESCRIPTION
This PR removes `CombineConfigures` as delegates can be combined merely by using the `+` operator to get the same effect/outcome.