### PR TITLE
Support testhost

### DIFF
--- a/test/Tmds.ExecFunction.Tests/Tmds.ExecFunction.Tests.csproj
+++ b/test/Tmds.ExecFunction.Tests/Tmds.ExecFunction.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/test/Tmds.ExecFunction.Tests/UnitTest1.cs
+++ b/test/Tmds.ExecFunction.Tests/UnitTest1.cs
@@ -58,5 +58,27 @@ namespace Tmds.Tests
                 };
             }
         );
+
+        [Fact]
+        public async Task GatherConsoleOut()
+        {
+            string outText = null;
+            FunctionExecutor FunctionExecutor = new FunctionExecutor(
+                o =>
+                {
+                    o.StartInfo.RedirectStandardOutput= true;
+                    o.OnExit = p =>
+                    {
+                        outText = p.StandardOutput.ReadToEnd();
+                    };
+                }
+            );
+
+            await FunctionExecutor.RunAsync(
+                () => { Console.Write("hello world"); return 0; });
+
+            Assert.Equal("hello world", outText);
+        }
+
     }
 }


### PR DESCRIPTION
It looks like in version 16 forward Microsoft.NET.Test.Sdk changed to running inside of a `testhost.exe` process instead of dotnet. This PR adds support for that change.