### PR TITLE
Support Visual Studio test runner

### DIFF
--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -201,6 +201,7 @@ namespace Tmds.Utils
         static ExecFunction()
         {
             HostFilename = Process.GetCurrentProcess().MainModule.FileName;
+
             string[] appArguments = null;
 
             // application is running as 'testhost'
@@ -217,6 +218,19 @@ namespace Tmds.Utils
 
                     Process proc = Process.GetProcessById(parentProcessId);
                     HostFilename = proc.MainModule.FileName;
+                }
+
+                if (HostFilename.EndsWith("vstest.console.exe"))
+                {
+                    // Running from Visual Studio,
+                    // doing a best-effort attempt to locate "dotnet.exe" based on the runtime path:
+                    string runtimePath = Path.GetDirectoryName(typeof(string).Assembly.Location);
+
+                    HostFilename = Path.Combine(runtimePath, "..", "..", "..", "dotnet.exe");
+                    if (!File.Exists(HostFilename))
+                    {
+                        HostFilename = null;
+                    }
                 }
 
                 if (HostFilename == null ||

--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -209,7 +209,6 @@ namespace Tmds.Utils
             if (HostFilename.EndsWith("/testhost") || HostFilename.EndsWith("\\testhost.exe"))
             {
                 HostFilename = null;
-
                 appArguments = GetApplicationArguments();
                 string parentProcessIdRaw = GetApplicationArgument(appArguments, "--parentprocessid");
                 if (parentProcessIdRaw != null)

--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -209,6 +209,7 @@ namespace Tmds.Utils
             if (HostFilename.EndsWith("/testhost") || HostFilename.EndsWith("\\testhost.exe"))
             {
                 HostFilename = null;
+
                 appArguments = GetApplicationArguments();
                 string parentProcessIdRaw = GetApplicationArgument(appArguments, "--parentprocessid");
                 if (parentProcessIdRaw != null)


### PR DESCRIPTION
Current logic cannot locate `dotnet.exe`, when running tests from Visual Studio on Windows, making the tests fail with `Application is running as testhost, unable to determine parent 'dotnet' process.`.

This is a naive way to overcome this issue which should work on typical dev systems.