### PR TITLE
Automatically attach debugger to subprocess

### DIFF
--- a/Tmds.ExecFunction.sln
+++ b/Tmds.ExecFunction.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "VsDebugger", "src\VsDebugger\VsDebugger.csproj", "{94B1096B-BE98-444B-BB78-2B136AD32663}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,6 +54,18 @@ Global
 		{444544CF-654F-4F8D-8976-9A899F0C29F6}.Release|x64.Build.0 = Release|Any CPU
 		{444544CF-654F-4F8D-8976-9A899F0C29F6}.Release|x86.ActiveCfg = Release|Any CPU
 		{444544CF-654F-4F8D-8976-9A899F0C29F6}.Release|x86.Build.0 = Release|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Debug|x64.Build.0 = Debug|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Debug|x86.Build.0 = Debug|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Release|Any CPU.Build.0 = Release|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Release|x64.ActiveCfg = Release|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Release|x64.Build.0 = Release|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Release|x86.ActiveCfg = Release|Any CPU
+		{94B1096B-BE98-444B-BB78-2B136AD32663}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +73,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F1668725-4E7A-44EF-9B92-B981C42F2493} = {625817A0-A9C9-4E3D-93FA-E4D0159EDAB2}
 		{444544CF-654F-4F8D-8976-9A899F0C29F6} = {E1EEAE41-5801-4027-B56E-0C1800CA783C}
+		{94B1096B-BE98-444B-BB78-2B136AD32663} = {625817A0-A9C9-4E3D-93FA-E4D0159EDAB2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FB15C44-88AC-4808-B3E6-52DAF5FDCD28}

--- a/Tmds.ExecFunction.v3.ncrunchsolution
+++ b/Tmds.ExecFunction.v3.ncrunchsolution
@@ -1,0 +1,5 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <SolutionConfigured>True</SolutionConfigured>
+  </Settings>
+</SolutionConfiguration>

--- a/src/Tmds.ExecFunction/Debugger.cs
+++ b/src/Tmds.ExecFunction/Debugger.cs
@@ -1,0 +1,241 @@
+﻿//MIT License
+
+//Copyright (c) 2019 Cy Scott
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+// implementation sourced from https://github.com/CyAScott/AppDomainAlternative/
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace Tmds.Utils
+{
+
+    /// <summary>
+    /// A wrapper for a <see cref="Process"/>.
+    /// </summary>
+    public abstract class Debugger
+    {
+        #region Visual Studio Debugger Support
+
+        /// <summary>
+        /// The environment variable name to use when finding the correct DTE version to use for attaching the debugger.
+        /// </summary>
+        public const string VsDteEnvironmentVariableName = "__VsDteEnvironmentVariableName__";
+
+        /// <summary>
+        /// Where the VsBugger.exe file is located.
+        /// </summary>
+        protected static string VsDebuggerLocation { get; }
+
+        /// <summary>
+        /// The Visual Studio DTE version to use for debugging.
+        /// </summary>
+        protected static string DteVersion { get; }
+
+#pragma warning disable 1591
+#pragma warning disable IDE1006 // Naming Styles
+        // ReSharper disable InconsistentNaming
+        // ReSharper disable StringLiteralTypo
+        // ReSharper disable UnusedMember.Local
+        [DllImport("ole32.dll")]
+        internal static extern int CLSIDFromProgID([MarshalAs(UnmanagedType.LPWStr)] string lpszProgID, out Guid pclsid);
+#pragma warning restore 1591
+#pragma warning restore IDE1006 // Naming Styles
+        // ReSharper restore InconsistentNaming
+        // ReSharper restore StringLiteralTypo
+        // ReSharper restore UnusedMember.Local
+
+        internal static bool TryToAttachDebugger(int pid)
+        {
+            if (!DebuggingSupported)
+            {
+                Debug.WriteLine("No Debugger Found");
+                return false;
+            }
+
+            try
+            {
+                using (var command = Process.Start(new ProcessStartInfo(VsDebuggerLocation, $"-pid:{pid} -ppid:{Process.GetCurrentProcess().Id} -dtev:{DteVersion} -debugger:attach")
+                {
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    WindowStyle = ProcessWindowStyle.Hidden,
+                    CreateNoWindow = true
+                }))
+                {
+                    // ReSharper disable once PossibleNullReferenceException
+                    command.WaitForExit(30000);//wait for 30 seconds to attach the debugger
+
+                    if (!command.HasExited)
+                    {
+                        command.Kill();
+                        throw new TimeoutException("Timed out when trying to attach debugger to process.");
+                    }
+
+                    var output = command.StandardOutput.ReadToEnd();
+
+                    if (command.ExitCode != 1)
+                    {
+                        throw new Exception(output);
+                    }
+                }
+
+                return true;
+            }
+            catch (Exception error)
+            {
+                Debug.WriteLine($"Unable to attach debugger to process ({pid}): {error}");
+
+                return false;
+            }
+        }
+
+        internal static void DetachDebugger(int pid)
+        {
+            try
+            {
+                using (var command = Process.Start(new ProcessStartInfo(VsDebuggerLocation, $"-pid:{pid} -dtev:{DteVersion} -debugger:detach")
+                {
+                    RedirectStandardOutput = true
+                }))
+                {
+                    // ReSharper disable once PossibleNullReferenceException
+                    command.WaitForExit(30000);//wait for 30 seconds to attach the debugger
+
+                    if (!command.HasExited)
+                    {
+                        command.Kill();
+                        throw new TimeoutException("Timed out when trying to attach debugger to process.");
+                    }
+
+                    if (command.ExitCode != 1)
+                    {
+                        throw new Exception(command.StandardOutput.ReadToEnd());
+                    }
+                }
+            }
+            catch (Exception error)
+            {
+                Debug.WriteLine($"Unable to detach debugger to process ({pid}): {error}");
+            }
+        }
+
+        #endregion
+
+        static Debugger()
+        {
+            try
+            {
+                // this path assumes we are in a nuget package
+                VsDebuggerLocation = Path.Combine(Path.GetDirectoryName(typeof(Debugger).Assembly.Location) ?? "", "..", "..", "contentFiles", "VsDebugger", "VsDebugger.exe");
+
+                if (!File.Exists(VsDebuggerLocation))
+                {
+                    VsDebuggerLocation = null;
+                    return;
+                }
+
+                /* The DTE version for Visual Studio is needed to attach the debugger to a child process.
+                 * The best way to find this information is to use the VsWhere utility developed by Microsoft.
+                 *
+                 * The DTE version can be set manually using an environment variable. This will be useful for
+                 * dev machines that have multiple versions of Visual Studio installed.
+                 *
+                 * This means that attaching the debugger to a child process is only supported on Windows.
+                 */
+                DteVersion = Environment.GetEnvironmentVariable(VsDteEnvironmentVariableName);
+
+                if (string.IsNullOrEmpty(DteVersion) || CLSIDFromProgID(DteVersion, out var classId) == 0 && classId != Guid.Empty)
+                {
+                    var programFiles = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+                    var vsWherePath = Path.Combine(programFiles, "Microsoft Visual Studio\\Installer\\vswhere.exe");
+                    if (!File.Exists(vsWherePath))
+                    {
+                        throw new Exception($"Unable to Find vswhere. Enure that it is installed.");
+                    }
+                    else
+                    {
+                        using (var process = new Process())
+                        {
+                            process.StartInfo.UseShellExecute = false;
+                            process.StartInfo.FileName = vsWherePath;
+                            process.StartInfo.RedirectStandardOutput = true;
+                            process.StartInfo.WindowStyle = ProcessWindowStyle.Hidden;
+                            process.Start();
+
+                            var output = process.StandardOutput.ReadToEnd();
+
+                            process.WaitForExit();
+
+                            using (var reader = new StringReader(output))
+                            {
+                                var regex = new Regex(@"^\s*installationVersion\s*:\s*(?<major>\d+)(\.\d+)*$", RegexOptions.IgnoreCase);
+                                while (reader.Peek() > -1)
+                                {
+                                    var match = regex.Match(reader.ReadLine() ?? "");
+                                    if (match.Success)
+                                    {
+                                        DteVersion = $"{match.Groups["major"].Value}.0";
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                //confirm the dte version is valid
+                if (CLSIDFromProgID($"VisualStudio.DTE.{DteVersion}", out classId) != 0 || classId == Guid.Empty)
+                {
+                    throw new Exception($"Unable to Find DTE Version \"VisualStudio.DTE.{DteVersion}\". Try setting the environment variable \"{VsDteEnvironmentVariableName}\" to the correct value for this machine.");
+                }
+
+                DebuggingSupported = true;
+            }
+            catch (Exception error)
+            {
+                DteVersion = null;
+                DebuggingSupported = false;
+
+                Debug.WriteLine($"Unable to find debugger: {error}");
+            }
+        }
+
+        internal Debugger()
+        {
+        }
+
+        /// <summary>
+        /// The process for the domain.
+        /// </summary>
+        public abstract Process Process { get; }
+
+        /// <summary>
+        /// True if debugging child processes is supported.
+        /// </summary>
+        public static bool DebuggingSupported { get; }
+
+    }
+
+}

--- a/src/Tmds.ExecFunction/ExecFunction.Program.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.Program.cs
@@ -49,7 +49,16 @@ namespace Tmds.Utils
                 string assemblyName = args[argIdx++];
                 string typeName = args[argIdx++];
                 string methodName = args[argIdx++];
-                string[] additionalArgs = args.SubArray(3);
+                bool debuggerEnabled = Boolean.Parse(args[argIdx++]);
+                string[] additionalArgs = args.SubArray(4);
+
+                if(debuggerEnabled)
+                {
+                    // wait for signal that debugger is attached
+
+                    Console.WriteLine("waiting for debugger");
+                    Console.ReadLine();
+                }
 
                 // Load the specified assembly, type, and method, then invoke the method.
                 // The program's exit code is the return value of the invoked method.

--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -16,87 +16,91 @@ namespace Tmds.Utils
 {
     public static partial class ExecFunction
     {
-        public static Process Start(Action action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure).process;
+        public static Process Start(Action action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure).process;
+        public static Process Start(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure).process;
+        public static Process Start(Func<int> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure).process;
+        public static Process Start(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure).process;
+        public static Process Start(Func<Task> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure).process;
+        public static Process Start(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure).process;
+        public static Process Start(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static Process Start(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure).process;
+        public static Process Start(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, execFunctionHostArgs: execFunctionHostArgs).process;
 
-        public static void Run(Action action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true);
+        public static void Run(Action action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true);
+        public static void Run(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true);
+        public static void Run(Func<int> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true);
+        public static void Run(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true);
+        public static void Run(Func<Task> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true);
+        public static void Run(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true);
+        public static void Run(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static void Run(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true);
+        public static void Run(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, waitForExit: true, execFunctionHostArgs: execFunctionHostArgs);
 
-        public static Task RunAsync(Action action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Action action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Func<int> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Func<Task> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), Array.Empty<string>(), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        public static Task RunAsync(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true).exitedTask;
+        public static Task RunAsync(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null, ExecFunctionHostArgs execFunctionHostArgs = null)
+            => Start(GetMethodInfo(action), args ?? throw new ArgumentNullException(nameof(args)), configure, returnTask: true, execFunctionHostArgs: execFunctionHostArgs).exitedTask;
 
-        private static (Process process, Task exitedTask) Start(MethodInfo method, string[] args, Action<ExecFunctionOptions> configure, bool waitForExit = false, bool returnTask = false)
+        private static (Process process, Task exitedTask) Start(MethodInfo method, string[] args, Action<ExecFunctionOptions> configure, ExecFunctionHostArgs execFunctionHostArgs = null, bool waitForExit = false, bool returnTask = false)
         {
             Process process = null;
             try
             {
                 process = new Process();
 
+                if(execFunctionHostArgs == null) { 
+                    execFunctionHostArgs = _execFunctiohHostArgsDefault.Value;
+                }
+
                 ExecFunctionOptions options = new ExecFunctionOptions(process.StartInfo);
-                ConfigureProcessStartInfoForMethodInvocation(method, args, options.StartInfo);
+                ConfigureProcessStartInfoForMethodInvocation(method, args, options.StartInfo, execFunctionHostArgs);
                 configure?.Invoke(options);
 
                 TaskCompletionSource<bool> tcs = null;
@@ -143,7 +147,7 @@ namespace Tmds.Utils
             }
         }
 
-        private static void ConfigureProcessStartInfoForMethodInvocation(MethodInfo method, string[] args, ProcessStartInfo psi)
+        private static void ConfigureProcessStartInfoForMethodInvocation(MethodInfo method, string[] args, ProcessStartInfo psi, ExecFunctionHostArgs execFunctionHostArgs)
         {
             if (method.ReturnType != typeof(void) &&
                 method.ReturnType != typeof(int) &&
@@ -165,9 +169,9 @@ namespace Tmds.Utils
             Assembly a = t.GetTypeInfo().Assembly;
             string programArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name });
             string functionArgs = PasteArguments.Paste(args);
-            string fullArgs = HostArguments + " " + " " + programArgs + " " + functionArgs;
+            string fullArgs = execFunctionHostArgs.HostArguments + " " + " " + programArgs + " " + functionArgs;
 
-            psi.FileName = HostFilename;
+            psi.FileName = execFunctionHostArgs.HostFilename;
             psi.Arguments = fullArgs;
         }
 
@@ -198,62 +202,76 @@ namespace Tmds.Utils
             return d.GetMethodInfo();
         }
 
-        static ExecFunction()
+
+        private static Lazy<ExecFunctionHostArgs> _execFunctiohHostArgsDefault = 
+            new Lazy<ExecFunctionHostArgs>(() => new ExecFunctionHostArgs(typeof(ExecFunction).Assembly.Location));
+
+        public class ExecFunctionHostArgs
         {
-            HostFilename = Process.GetCurrentProcess().MainModule.FileName;
-            string[] appArguments = null;
-
-            // application is running as 'testhost'
-            // try to find parent 'dotnet' host process.
-            if (HostFilename.EndsWith("/testhost") || HostFilename.EndsWith("\\testhost.exe"))
+            public ExecFunctionHostArgs(string execFunctionAssembly)
             {
-                HostFilename = null;
+                HostFilename = Process.GetCurrentProcess().MainModule.FileName;
+                string[] appArguments = null;
 
-                appArguments = GetApplicationArguments();
-                string parentProcessIdRaw = GetApplicationArgument(appArguments, "--parentprocessid");
-                if (parentProcessIdRaw != null)
+                // application is running as 'testhost'
+                // try to find parent 'dotnet' host process.
+                if (HostFilename.EndsWith("/testhost") || HostFilename.EndsWith("\\testhost.exe"))
                 {
-                    int parentProcessId = int.Parse(parentProcessIdRaw);
+                    HostFilename = null;
 
-                    Process proc = Process.GetProcessById(parentProcessId);
-                    HostFilename = proc.MainModule.FileName;
+                    appArguments = GetApplicationArguments();
+                    string parentProcessIdRaw = GetApplicationArgument(appArguments, "--parentprocessid");
+                    if (parentProcessIdRaw != null)
+                    {
+                        int parentProcessId = int.Parse(parentProcessIdRaw);
+
+                        Process proc = Process.GetProcessById(parentProcessId);
+                        HostFilename = proc.MainModule.FileName;
+                    }
+
+                    if (HostFilename == null ||
+                       !((HostFilename.EndsWith("/dotnet") || HostFilename.EndsWith("\\dotnet.exe"))))
+                    {
+                        throw new NotSupportedException("Application is running as testhost, unable to determine parent 'dotnet' process.");
+                    }
                 }
 
-                if (HostFilename == null ||
-                   !((HostFilename.EndsWith("/dotnet") || HostFilename.EndsWith("\\dotnet.exe"))))
+                // application is running as 'dotnet exec'.
+                if (HostFilename.EndsWith("/dotnet") || HostFilename.EndsWith("\\dotnet.exe"))
                 {
-                    throw new NotSupportedException("Application is running as testhost, unable to determine parent 'dotnet' process.");
+                    string entryAssemblyWithoutExtension = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
+                                                                        Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
+                    appArguments = appArguments ?? GetApplicationArguments();
+
+                    string runtimeConfigFile = GetApplicationArgument(appArguments, "--runtimeconfig");
+                    if (runtimeConfigFile == null)
+                    {
+                        runtimeConfigFile = entryAssemblyWithoutExtension + ".runtimeconfig.json";
+                    }
+
+                    string depsFile = GetApplicationArgument(appArguments, "--depsfile");
+                    if (depsFile == null)
+                    {
+                        depsFile = entryAssemblyWithoutExtension + ".deps.json";
+                    }
+
+                    HostArguments = PasteArguments.Paste(new string[] { "exec", "--runtimeconfig", runtimeConfigFile, "--depsfile", depsFile, execFunctionAssembly });
+                }
+                // application is an apphost. Main method must call 'RunFunction.Program.Main' for CommandName.
+                else
+                {
+                    HostArguments = CommandName;
                 }
             }
 
-            // application is running as 'dotnet exec'.
-            if (HostFilename.EndsWith("/dotnet") || HostFilename.EndsWith("\\dotnet.exe"))
+            public ExecFunctionHostArgs(string HostFilename, string HostArguments)
             {
-                string execFunctionAssembly = typeof(ExecFunction).Assembly.Location;
-
-                string entryAssemblyWithoutExtension = Path.Combine(Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
-                                                                    Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly().Location));
-                appArguments = appArguments ?? GetApplicationArguments();
-
-                string runtimeConfigFile = GetApplicationArgument(appArguments, "--runtimeconfig");
-                if (runtimeConfigFile == null)
-                {
-                    runtimeConfigFile = entryAssemblyWithoutExtension + ".runtimeconfig.json";
-                }
-
-                string depsFile = GetApplicationArgument(appArguments, "--depsfile");
-                if (depsFile == null)
-                {
-                    depsFile = entryAssemblyWithoutExtension + ".deps.json";
-                }
-
-                HostArguments = PasteArguments.Paste(new string[] { "exec", "--runtimeconfig", runtimeConfigFile, "--depsfile", depsFile, execFunctionAssembly });
+                this.HostFilename = HostFilename;
+                this.HostArguments = HostArguments;
             }
-            // application is an apphost. Main method must call 'RunFunction.Program.Main' for CommandName.
-            else
-            {
-                HostArguments = CommandName;
-            }
+
+            public readonly string HostFilename;
+            public readonly string HostArguments;
         }
 
         private static string GetApplicationArgument(string[] arguments, string name)
@@ -422,7 +440,5 @@ namespace Tmds.Utils
             }
         }
 
-        private static readonly string HostFilename;
-        private static readonly string HostArguments;
     }
 }

--- a/src/Tmds.ExecFunction/FunctionExecutor.cs
+++ b/src/Tmds.ExecFunction/FunctionExecutor.cs
@@ -11,82 +11,84 @@ namespace Tmds.Utils
     public class FunctionExecutor
     {
         private readonly Action<ExecFunctionOptions> _configure;
+        private readonly ExecFunction.ExecFunctionHostArgs _execFunctionHostArgs;
 
-        public FunctionExecutor(Action<ExecFunctionOptions> configure)
+        public FunctionExecutor(Action<ExecFunctionOptions> configure, ExecFunction.ExecFunctionHostArgs execFunctionHostArgs = null)
         {
             _configure = configure;
+            _execFunctionHostArgs = execFunctionHostArgs;
         }
 
         public Process Start(Action action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, _configure + configure);
+            => ExecFunction.Start(action, _configure + configure.Invoke, _execFunctionHostArgs);
 
         public Process Start(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, _configure + configure);
+            => ExecFunction.Start(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Process Start(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, _configure + configure);
+            => ExecFunction.Start(action, _configure + configure, _execFunctionHostArgs);
 
         public Process Start(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, _configure + configure);
+            => ExecFunction.Start(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Process Start(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, _configure + configure);
+            => ExecFunction.Start(action, _configure + configure, _execFunctionHostArgs);
 
         public Process Start(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, _configure + configure);
+            => ExecFunction.Start(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Process Start(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, _configure + configure);
+            => ExecFunction.Start(action, _configure + configure, _execFunctionHostArgs);
 
         public Process Start(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Start(action, args, _configure + configure);
+            => ExecFunction.Start(action, args, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Action action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, _configure + configure);
+            => ExecFunction.Run(action, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, _configure + configure);
+            => ExecFunction.Run(action, args, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, _configure + configure);
+            => ExecFunction.Run(action, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, _configure + configure);
+            => ExecFunction.Run(action, args, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, _configure + configure);
+            => ExecFunction.Run(action, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, _configure + configure);
+            => ExecFunction.Run(action, args, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, _configure + configure);
+            => ExecFunction.Run(action, _configure + configure, _execFunctionHostArgs);
 
         public void Run(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.Run(action, args, _configure + configure);
+            => ExecFunction.Run(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Action action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, _configure + configure);
+            => ExecFunction.RunAsync(action, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Action<string[]> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, _configure + configure);
+            => ExecFunction.RunAsync(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Func<int> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, _configure + configure);
+            => ExecFunction.RunAsync(action, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Func<string[], int> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, _configure + configure);
+            => ExecFunction.RunAsync(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Func<Task> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, _configure + configure);
+            => ExecFunction.RunAsync(action, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Func<string[], Task> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, _configure + configure);
+            => ExecFunction.RunAsync(action, args, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Func<Task<int>> action, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, _configure + configure);
+            => ExecFunction.RunAsync(action, _configure + configure, _execFunctionHostArgs);
 
         public Task RunAsync(Func<string[], Task<int>> action, string[] args, Action<ExecFunctionOptions> configure = null)
-            => ExecFunction.RunAsync(action, args, _configure + configure);
+            => ExecFunction.RunAsync(action, args, _configure + configure, _execFunctionHostArgs);
     }
 }

--- a/src/Tmds.ExecFunction/Properties/AssemblyInfo.cs
+++ b/src/Tmds.ExecFunction/Properties/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using System.Reflection;
 
-[assembly: AssemblyKeyFile("Tmds.ExecFunction.snk")]
+//[assembly: AssemblyKeyFile("Tmds.ExecFunction.snk")]

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,4 +13,23 @@
     <Copyright>Tom Deseyn</Copyright>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\VsDebugger\VsDebugger.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+      <Private>true</Private>
+    </ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup Label="FilesToCopy">
+    <Content Include="Tmds.ExecFunction.targets" PackagePath="build/Tmds.ExecFunction.targets" />
+    <Content Include="$(SolutionDir)\src\VsDebugger\bin\$(Configuration)\*.*" Pack="true" PackagePath="contentFiles\VsDebugger">
+      <PackageCopyToOutput>true</PackageCopyToOutput>
+    </Content>
+  </ItemGroup>
+  
 </Project>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <VsDebugger Include="$(MSBuildThisFileDirectory)\..\contentFiles\VsDebugger\*.*" />
+  </ItemGroup>
+  <Target Name="CopyVsDebugger" BeforeTargets="Build">
+    <Copy SourceFiles="@(VsDebugger)" DestinationFolder="$(TargetDir)\VsDebugger" />
+  </Target>
+</Project>

--- a/src/VsDebugger/Program.cs
+++ b/src/VsDebugger/Program.cs
@@ -1,0 +1,223 @@
+﻿//MIT License
+
+//Copyright (c) 2019 Cy Scott
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+// implementation sourced from https://github.com/CyAScott/AppDomainAlternative/
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text.RegularExpressions;
+using EnvDTE;
+using OsProcess = System.Diagnostics.Process;
+
+namespace VsDebugger
+{
+    public static class Program
+    {
+        public static int Main(string[] commandArgs)
+        {
+            var args = commandArgs
+                .Where(arg => arg.Length > 0 && arg[0] == '-')
+                .Select(arg => arg.Split(new [] { ':' }, 2))
+                .ToDictionary(arg => arg[0].Substring(1).Trim(), arg => arg.Length == 1 ? "" : arg[1].Trim(), StringComparer.OrdinalIgnoreCase);
+
+            if (!args.TryGetValue("pid", out var pidStr) || !int.TryParse(pidStr, out var pid))
+            {
+                Console.WriteLine("Missing command line argument \"-pid:...\" with the target process id.");
+                return 2;
+            }
+
+            AttachMode attachMode;
+            try
+            {
+                if (!args.TryGetValue("debugger", out var mode) || string.Equals(mode, "attach", StringComparison.OrdinalIgnoreCase))
+                {
+                    attachMode = AttachMode.Attach;
+                }
+                else if (string.Equals(mode, "detach", StringComparison.OrdinalIgnoreCase))
+                {
+                    attachMode = AttachMode.Detach;
+                }
+                else
+                {
+                    throw new Exception();
+                }
+            }
+            catch
+            {
+                Console.WriteLine($"Unable to attach debugger to process ID: {pid}");
+                return 4;
+            }
+
+            int parentProcessId;
+            try
+            {
+                if (!args.TryGetValue("ppid", out var parentProcessIdStr) || !int.TryParse(parentProcessIdStr, out parentProcessId))
+                {
+                    parentProcessId = -1;
+                }
+            }
+            catch
+            {
+                parentProcessId = -1;
+            }
+
+            var dteInstances = GetInstances();
+            var dte = dteInstances.SingleOrDefault(x => x.Debugger.DebuggedProcesses.OfType<Process>().Any(y => y.ProcessID == parentProcessId));
+            if(dte == null)
+            {
+                Console.WriteLine($"Unable to find the DTE instance for the parent process id \"{parentProcessId}\"");
+                return 3;
+            }
+
+            MessageFilter.Register();
+
+            Process target;
+            try
+            {
+                if (attachMode == AttachMode.Detach)
+                {
+                    target = dte.Debugger.DebuggedProcesses.OfType<Process>().FirstOrDefault(process => process.ProcessID == pid);
+                }
+                else
+                {
+                    Console.WriteLine($"Ppid: {parentProcessId}");
+                    var parentProcess = parentProcessId == -1 ? null :
+                        dte.Debugger.DebuggedProcesses.OfType<Process>().FirstOrDefault(process => process.ProcessID == parentProcessId) ??
+                        dte.Debugger.LocalProcesses.OfType<Process>().FirstOrDefault(process => process.ProcessID == parentProcessId);
+
+                    target = (parentProcess?.Parent?.LocalProcesses ?? dte.Debugger.LocalProcesses).OfType<Process>().FirstOrDefault(process => process.ProcessID == pid);
+                }
+            }
+            catch (Exception error)
+            {
+                Console.WriteLine($"Unable to find processes to debug: {error}");
+                return 5;
+            }
+
+            if (target == null)
+            {
+                Console.WriteLine($"Unable to find process ID: {pid}");
+                return 6;
+            }
+
+            try
+            {
+                if (attachMode == AttachMode.Attach)
+                {
+                    target.Attach();
+                }
+                else
+                {
+                    target.Detach(false);
+                }
+            }
+            catch
+            {
+                Console.WriteLine($"Unable to attach/detach the debugger to/from process ID: {pid}");
+                return 7;
+            }
+
+            MessageFilter.Revoke();
+
+            return 1;
+        }
+
+        [DllImport("ole32.dll")]
+        private static extern int CreateBindCtx(uint reserved, out IBindCtx ppbc);
+
+        [DllImport("ole32.dll")]
+        private static extern int GetRunningObjectTable(int reserved, out IRunningObjectTable prot);
+
+        static System.Collections.Generic.IEnumerable<DTE> GetInstances()
+        {
+            IRunningObjectTable rot;
+            IEnumMoniker enumMoniker;
+            int retVal = GetRunningObjectTable(0, out rot);
+
+            if (retVal == 0)
+            {
+                rot.EnumRunning(out enumMoniker);
+
+                IntPtr fetched = IntPtr.Zero;
+                IMoniker[] moniker = new IMoniker[1];
+                while (enumMoniker.Next(1, moniker, fetched) == 0)
+                {
+                    IBindCtx bindCtx;
+                    CreateBindCtx(0, out bindCtx);
+                    string displayName;
+                    moniker[0].GetDisplayName(bindCtx, null, out displayName);
+                    bool isVisualStudio = displayName.StartsWith("!VisualStudio");
+                    if (isVisualStudio)
+                    {
+                        object obj;
+                        rot.GetObject(moniker[0], out obj);
+                        var dte = obj as DTE;
+                        yield return dte;
+                    }
+                }
+            }
+        }
+    }
+
+    public enum AttachMode
+    {
+        Attach,
+        Detach
+    }
+
+    [ComImport, Guid("00000016-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IOleMessageFilter
+    {
+        [PreserveSig]
+        int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
+
+        [PreserveSig]
+        int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
+
+        [PreserveSig]
+        int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
+    }
+
+    public class MessageFilter : IOleMessageFilter
+    {
+        private const int handled = 0, retryAllowed = 2, retry = 99, cancel = -1, waitAndDispatch = 2;
+
+        int IOleMessageFilter.HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo) => handled;
+
+        int IOleMessageFilter.RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType) => dwRejectType == retryAllowed ? retry : cancel;
+
+        int IOleMessageFilter.MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType) => waitAndDispatch;
+
+        public static void Register() => CoRegisterMessageFilter(new MessageFilter());
+
+        public static void Revoke() => CoRegisterMessageFilter(null);
+
+        public static void CoRegisterMessageFilter(IOleMessageFilter newFilter) => CoRegisterMessageFilter(newFilter, out _);
+
+        [DllImport("Ole32.dll")]
+        public static extern int CoRegisterMessageFilter(IOleMessageFilter newFilter, out IOleMessageFilter oldFilter);
+    }
+
+}

--- a/src/VsDebugger/VsDebugger.csproj
+++ b/src/VsDebugger/VsDebugger.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <LangVersion>7.1</LangVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EnvDTE" Version="8.0.2" />
+    <PackageReference Include="EnvDTE80" Version="8.0.3" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Uses the [Visual Studio DTE](https://docs.microsoft.com/en-us/dotnet/api/envdte.dte?view=visualstudiosdk-2019) to attach to the sub process automatically. I think packaging is implemented properly, I manually packaged this and added it to another project and saw it work. The actual implementation was sourced from https://github.com/CyAScott/AppDomainAlternative/, which has an MIT license.