### PR TITLE
Automatically attach debugger to subprocess

### DIFF
--- a/Tmds.ExecFunction.sln
+++ b/Tmds.ExecFunction.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29102.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{625817A0-A9C9-4E3D-93FA-E4D0159EDAB2}"
 EndProject
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		LICENSE = LICENSE
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tmds.ExecFunction.VsDebugger", "src\Tmds.ExecFunction.VsDebugger\Tmds.ExecFunction.VsDebugger.csproj", "{68E26146-C5F5-4709-BDF8-2C735435047E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -52,6 +54,18 @@ Global
 		{444544CF-654F-4F8D-8976-9A899F0C29F6}.Release|x64.Build.0 = Release|Any CPU
 		{444544CF-654F-4F8D-8976-9A899F0C29F6}.Release|x86.ActiveCfg = Release|Any CPU
 		{444544CF-654F-4F8D-8976-9A899F0C29F6}.Release|x86.Build.0 = Release|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Debug|x64.Build.0 = Debug|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Debug|x86.Build.0 = Debug|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Release|x64.ActiveCfg = Release|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Release|x64.Build.0 = Release|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Release|x86.ActiveCfg = Release|Any CPU
+		{68E26146-C5F5-4709-BDF8-2C735435047E}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -59,6 +73,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{F1668725-4E7A-44EF-9B92-B981C42F2493} = {625817A0-A9C9-4E3D-93FA-E4D0159EDAB2}
 		{444544CF-654F-4F8D-8976-9A899F0C29F6} = {E1EEAE41-5801-4027-B56E-0C1800CA783C}
+		{68E26146-C5F5-4709-BDF8-2C735435047E} = {625817A0-A9C9-4E3D-93FA-E4D0159EDAB2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3FB15C44-88AC-4808-B3E6-52DAF5FDCD28}

--- a/src/Tmds.ExecFunction.VsDebugger/DebuggerAttachHelper.cs
+++ b/src/Tmds.ExecFunction.VsDebugger/DebuggerAttachHelper.cs
@@ -1,0 +1,12 @@
+﻿using System.Diagnostics;
+
+namespace System
+{
+    public static class DebuggerAttachHelper
+    {
+        public static void AttachTo(int targetProcessId)
+        {
+            VsDebuggerAttacher.AttachToTargetProcessDebugger(Process.GetCurrentProcess().Id, targetProcessId);
+        }
+    }
+}

--- a/src/Tmds.ExecFunction.VsDebugger/Tmds.ExecFunction.VsDebugger.csproj
+++ b/src/Tmds.ExecFunction.VsDebugger/Tmds.ExecFunction.VsDebugger.csproj
@@ -1,8 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Tmds.ExecFunction</RootNamespace>
     <TargetFramework>netstandard2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tmds.ExecFunction.VsDebugger/Tmds.ExecFunction.VsDebugger.csproj
+++ b/src/Tmds.ExecFunction.VsDebugger/Tmds.ExecFunction.VsDebugger.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <RootNamespace>Tmds.ExecFunction</RootNamespace>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="EnvDTE" Version="16.7.30328.74" />
+  </ItemGroup>
+</Project>

--- a/src/Tmds.ExecFunction.VsDebugger/VsDebuggerAttacher.cs
+++ b/src/Tmds.ExecFunction.VsDebugger/VsDebuggerAttacher.cs
@@ -1,0 +1,214 @@
+﻿//MIT License
+
+//Copyright (c) 2019 Cy Scott
+
+//Permission is hereby granted, free of charge, to any person obtaining a copy
+//of this software and associated documentation files (the "Software"), to deal
+//in the Software without restriction, including without limitation the rights
+//to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//copies of the Software, and to permit persons to whom the Software is
+//furnished to do so, subject to the following conditions:
+
+//The above copyright notice and this permission notice shall be included in all
+//copies or substantial portions of the Software.
+
+//THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//SOFTWARE.
+
+// implementation sourced from https://github.com/CyAScott/AppDomainAlternative/
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+using EnvDTE;
+
+namespace System
+{
+    public static class VsDebuggerAttacher
+    {
+        [ComImport, Guid("00000016-0000-0000-C000-000000000046"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface IOleMessageFilter
+        {
+            [PreserveSig]
+            int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
+
+            [PreserveSig]
+            int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
+
+            [PreserveSig]
+            int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
+        }
+
+        public static void AttachToTargetProcessDebugger(int pid, int targetPid)
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                Console.Error.WriteLine($"{nameof(VsDebuggerAttacher)}.{nameof(AttachToTargetProcessDebugger)} can not run except windows. Nothing will happen for process {pid} and {targetPid}.");
+                return;
+            }
+
+            if (Threading.Thread.CurrentThread.GetApartmentState() == Threading.ApartmentState.STA)
+            {
+                InternalAttachToTargetProcessDebugger(pid, targetPid);
+            }
+            else
+            {
+                var thread = new Threading.Thread(() =>
+                {
+                    InternalAttachToTargetProcessDebugger(pid, targetPid);
+                });
+                thread.SetApartmentState(Threading.ApartmentState.STA);
+                thread.Name = $"VsDebuggerAttacher {pid} -> {targetPid}'s debugger";
+                thread.Start();
+                thread.Join();
+            }
+        }
+
+        [DllImport("ole32.dll")]
+        private static extern int CreateBindCtx(uint reserved, out IBindCtx ppbc);
+
+        private static IEnumerable<DTE> GetInstances()
+        {
+            int retVal = GetRunningObjectTable(0, out IRunningObjectTable rot);
+
+            if (retVal == 0)
+            {
+                rot.EnumRunning(out IEnumMoniker enumMoniker);
+
+                IntPtr fetched = IntPtr.Zero;
+                IMoniker[] moniker = new IMoniker[1];
+                while (enumMoniker.Next(1, moniker, fetched) == 0)
+                {
+                    CreateBindCtx(0, out IBindCtx bindCtx);
+                    moniker[0].GetDisplayName(bindCtx, null, out string displayName);
+                    bool isVisualStudio = displayName.StartsWith("!VisualStudio");
+                    if (isVisualStudio)
+                    {
+                        rot.GetObject(moniker[0], out object obj);
+                        if (obj is DTE dte)
+                        {
+                            yield return dte;
+                        }
+                    }
+                }
+            }
+        }
+
+        [DllImport("ole32.dll")]
+        private static extern int GetRunningObjectTable(int reserved, out IRunningObjectTable prot);
+
+        private static void InternalAttachToTargetProcessDebugger(int pid, int targetPid)
+        {
+            if (pid < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(pid));
+            }
+
+            if (targetPid < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(targetPid));
+            }
+
+            var dteInstances = GetInstances();
+
+            DTE dte = null;
+
+            //try 3 times
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    dte = dteInstances.SingleOrDefault(x => x.Debugger.DebuggedProcesses.OfType<Process>().Any(y => y.ProcessID == targetPid));
+                }
+                catch (COMException)
+                {
+                    //Wait init
+                    Threading.Thread.Sleep(500);
+                }
+            }
+
+            if (dte == null)
+            {
+                throw new InvalidOperationException($"Unable to find the DTE instance for the process id \"{targetPid}\"");
+            }
+
+            MessageFilter.Register();
+
+            try
+            {
+                Process target;
+                try
+                {
+                    target = dte.Debugger.LocalProcesses.OfType<Process>().FirstOrDefault(process => process.ProcessID == pid);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Unable to find process {pid} to debug.", ex);
+                }
+
+                if (target == null)
+                {
+                    throw new InvalidOperationException($"Unable to find process ID: {pid}");
+                }
+
+                try
+                {
+                    target.Attach();
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException($"Unable to attach the debugger for process ID: {pid}", ex);
+                }
+            }
+            finally
+            {
+                MessageFilter.Revoke();
+            }
+        }
+
+        private sealed class MessageFilter : IOleMessageFilter
+        {
+            private const int Handled = 0, RetryAllowed = 2, Retry = 99, Cancel = -1, WaitAndDispatch = 2;
+
+            public static void CoRegisterMessageFilter(IOleMessageFilter newFilter)
+            {
+                CoRegisterMessageFilter(newFilter, out _);
+            }
+
+            [DllImport("Ole32.dll")]
+            public static extern int CoRegisterMessageFilter(IOleMessageFilter newFilter, out IOleMessageFilter oldFilter);
+
+            public static void Register()
+            {
+                CoRegisterMessageFilter(new MessageFilter());
+            }
+
+            public static void Revoke()
+            {
+                CoRegisterMessageFilter(null);
+            }
+
+            int IOleMessageFilter.HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo)
+            {
+                return Handled;
+            }
+
+            int IOleMessageFilter.MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType)
+            {
+                return WaitAndDispatch;
+            }
+
+            int IOleMessageFilter.RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType)
+            {
+                return dwRejectType == RetryAllowed ? Retry : Cancel;
+            }
+        }
+    }
+}

--- a/src/Tmds.ExecFunction.VsDebugger/VsDebuggerAttacher.cs
+++ b/src/Tmds.ExecFunction.VsDebugger/VsDebuggerAttacher.cs
@@ -116,7 +116,7 @@ namespace System
                 throw new ArgumentOutOfRangeException(nameof(targetPid));
             }
 
-            var dteInstances = GetInstances();
+            IEnumerable<DTE> dteInstances = GetInstances();
 
             DTE dte = null;
 

--- a/src/Tmds.ExecFunction/DebuggerAttacher.cs
+++ b/src/Tmds.ExecFunction/DebuggerAttacher.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+
+namespace Tmds.Utils
+{
+    public static class DebuggerAttacher
+    {
+        public const string VsDebuggerLibraryFileName = "Tmds.ExecFunction.VsDebugger.dll";
+
+        public static void TryAttach(int targetProcessId)
+        {
+            if (Debugger.IsAttached
+                || Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                return;
+            }
+            var dllPath = Path.Combine(Environment.CurrentDirectory, VsDebuggerLibraryFileName);
+
+            if (!File.Exists(dllPath))
+            {
+                return;
+            }
+
+            var assembly = Assembly.LoadFile(dllPath);
+
+            var attachMethod = assembly.GetType("System.DebuggerAttachHelper", false, true)
+                                       ?.GetMethod("AttachTo", BindingFlags.Public | BindingFlags.Static);
+
+            attachMethod?.Invoke(null, new object[] { targetProcessId });
+        }
+    }
+}

--- a/src/Tmds.ExecFunction/DebuggerAttacher.cs
+++ b/src/Tmds.ExecFunction/DebuggerAttacher.cs
@@ -16,17 +16,17 @@ namespace Tmds.Utils
             {
                 return;
             }
-            var dllPath = Path.Combine(Environment.CurrentDirectory, VsDebuggerLibraryFileName);
+            string dllPath = Path.Combine(Environment.CurrentDirectory, VsDebuggerLibraryFileName);
 
             if (!File.Exists(dllPath))
             {
                 return;
             }
 
-            var assembly = Assembly.LoadFile(dllPath);
+            Assembly assembly = Assembly.LoadFile(dllPath);
 
-            var attachMethod = assembly.GetType("System.DebuggerAttachHelper", false, true)
-                                       ?.GetMethod("AttachTo", BindingFlags.Public | BindingFlags.Static);
+            MethodInfo attachMethod = assembly.GetType("System.DebuggerAttachHelper", false, true)
+                                              ?.GetMethod("AttachTo", BindingFlags.Public | BindingFlags.Static);
 
             attachMethod?.Invoke(null, new object[] { targetProcessId });
         }

--- a/src/Tmds.ExecFunction/ExecFunction.Program.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.Program.cs
@@ -55,7 +55,7 @@ namespace Tmds.Utils
 
                 if (enableDebuggerAttach)
                 {
-                    var parentProcessId = int.Parse(parentProcessIdStr);
+                    int parentProcessId = int.Parse(parentProcessIdStr);
                     DebuggerAttacher.TryAttach(parentProcessId);
                 }
 

--- a/src/Tmds.ExecFunction/ExecFunction.Program.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.Program.cs
@@ -50,6 +50,14 @@ namespace Tmds.Utils
                 string typeName = args[argIdx++];
                 string methodName = args[argIdx++];
                 string[] additionalArgs = args.SubArray(3);
+                bool enableDebuggerAttach = bool.Parse(args[argIdx++]);
+                string parentProcessIdStr = args[argIdx++];
+
+                if (enableDebuggerAttach)
+                {
+                    var parentProcessId = int.Parse(parentProcessIdStr);
+                    DebuggerAttacher.TryAttach(parentProcessId);
+                }
 
                 // Load the specified assembly, type, and method, then invoke the method.
                 // The program's exit code is the return value of the invoked method.

--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -163,7 +163,11 @@ namespace Tmds.Utils
             // If we need the host (if it exists), use it, otherwise target the console app directly.
             Type t = method.DeclaringType;
             Assembly a = t.GetTypeInfo().Assembly;
-            string programArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name });
+
+            var enableDebuggerAttach = Debugger.IsAttached && Environment.OSVersion.Platform == PlatformID.Win32NT;
+            var pid = Process.GetCurrentProcess().Id;
+
+            string programArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name, enableDebuggerAttach.ToString(System.Globalization.CultureInfo.InvariantCulture), pid.ToString(System.Globalization.CultureInfo.InvariantCulture) });
             string functionArgs = PasteArguments.Paste(args);
             string fullArgs = HostArguments + " " + " " + programArgs + " " + functionArgs;
 

--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -164,8 +164,8 @@ namespace Tmds.Utils
             Type t = method.DeclaringType;
             Assembly a = t.GetTypeInfo().Assembly;
 
-            var enableDebuggerAttach = Debugger.IsAttached && Environment.OSVersion.Platform == PlatformID.Win32NT;
-            var pid = Process.GetCurrentProcess().Id;
+            bool enableDebuggerAttach = Debugger.IsAttached && Environment.OSVersion.Platform == PlatformID.Win32NT;
+            int pid = Process.GetCurrentProcess().Id;
 
             string programArgs = PasteArguments.Paste(new string[] { a.FullName, t.FullName, method.Name, enableDebuggerAttach.ToString(System.Globalization.CultureInfo.InvariantCulture), pid.ToString(System.Globalization.CultureInfo.InvariantCulture) });
             string functionArgs = PasteArguments.Paste(args);

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
@@ -18,7 +18,8 @@
 
     <ProjectReference Include="..\Tmds.ExecFunction.VsDebugger\Tmds.ExecFunction.VsDebugger.csproj" PrivateAssets="All" />
 
-    <Content Include="..\Tmds.ExecFunction.VsDebugger\bin\$(Configuration)\$(TargetFramework)\**\*" Link="tools/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" PackagePath="tools/any/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" />
+    <!--<Content Include="..\Tmds.ExecFunction.VsDebugger\bin\$(Configuration)\$(TargetFramework)\**\*" Link="tools/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" PackagePath="tools/any/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" />-->
+    <Content Include="..\Tmds.ExecFunction.VsDebugger\bin\$(Configuration)\$(TargetFramework)\Tmds.ExecFunction.VsDebugger.dll" Link="tools/vsdebugger/Tmds.ExecFunction.VsDebugger.dll" PackagePath="tools/any/vsdebugger/Tmds.ExecFunction.VsDebugger.dll" />
   </ItemGroup>
 
 </Project>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,5 +12,13 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Tom Deseyn</Copyright>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="Tmds.ExecFunction.targets" PackagePath="build/$(PackageId).targets" />
+
+    <ProjectReference Include="..\Tmds.ExecFunction.VsDebugger\Tmds.ExecFunction.VsDebugger.csproj" PrivateAssets="All" />
+
+    <Content Include="..\Tmds.ExecFunction.VsDebugger\bin\$(Configuration)\$(TargetFramework)\**\*" Link="tools/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" PackagePath="tools/any/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" />
+  </ItemGroup>
 
 </Project>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
@@ -1,0 +1,9 @@
+﻿<Project>
+  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
+    <PackageReference Include="EnvDTE" Version="16.7.30328.74" />
+    <VsDebuggerFile Include="$(MSBuildThisFileDirectory)\..\tools\any\vsdebugger\**\*" />
+  </ItemGroup>
+  <Target Name="CopyVsDebuggerFileOnBuild" Condition="'$(Configuration)' == 'Debug'" BeforeTargets="Build">
+    <Copy SourceFiles="@(VsDebuggerFile)" DestinationFolder="$(TargetDir)\" />
+  </Target>
+</Project>


### PR DESCRIPTION
When reference package `Tmds.ExecFunction.VsDebugger` the subprocess will attach debugger automatically. 

Use conditional reference will avoid reference EnvDTE for release.
```C#
<ItemGroup Condition="'$(Configuration)' == 'Debug'">
  <ProjectReference Include="..\src\Tmds.ExecFunction.VsDebugger\Tmds.ExecFunction.VsDebugger.csproj" />
</ItemGroup>
```