### PR TITLE
replace dynamic reference envdte package with copy file.

### DIFF
--- a/src/Tmds.ExecFunction.VsDebugger/Tmds.ExecFunction.VsDebugger.csproj
+++ b/src/Tmds.ExecFunction.VsDebugger/Tmds.ExecFunction.VsDebugger.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
@@ -24,7 +24,7 @@
 
     <ProjectReference Include="..\Tmds.ExecFunction.VsDebugger\Tmds.ExecFunction.VsDebugger.csproj" PrivateAssets="All" />
 
-    <Content Include="..\Tmds.ExecFunction.VsDebugger\bin\$(Configuration)\$(TargetFramework)\Tmds.ExecFunction.VsDebugger.dll" Link="tools/vsdebugger/Tmds.ExecFunction.VsDebugger.dll" PackagePath="tools/any/vsdebugger/Tmds.ExecFunction.VsDebugger.dll" />
+    <Content Include="..\Tmds.ExecFunction.VsDebugger\bin\$(Configuration)\$(TargetFramework)\*.dll" Link="tools/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" PackagePath="tools/any/vsdebugger/%(RecursiveDir)%(FileName)%(Extension)" />
   </ItemGroup>
 
 </Project>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
@@ -1,6 +1,5 @@
 ﻿<Project>
   <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="EnvDTE" Version="16.7.30328.74" />
     <VsDebuggerFile Include="$(MSBuildThisFileDirectory)\..\tools\any\vsdebugger\**\*" />
   </ItemGroup>
   <Target Name="CopyVsDebuggerFileOnBuild" Condition="'$(Configuration)' == 'Debug'" BeforeTargets="Build">


### PR DESCRIPTION
for the issue [ envdte package shows up as soon as Tmds.ExecFunction is installed #16 ](https://github.com/tmds/Tmds.ExecFunction/issues/16) we can make the package include envdte's dlls instead of package reference.