### PR TITLE
Ignore case when finding application argument

### DIFF
--- a/src/Tmds.ExecFunction/ExecFunction.cs
+++ b/src/Tmds.ExecFunction/ExecFunction.cs
@@ -264,7 +264,7 @@ namespace Tmds.Utils
         {
             for (int i = 0; i < arguments.Length - 1; i++)
             {
-                if (arguments[i] == name)
+                if (string.Equals(arguments[i], name, StringComparison.OrdinalIgnoreCase))
                 {
                     return arguments[i + 1];
                 }


### PR DESCRIPTION
The `--runtimeConfig` argument is also valid with a capital letter `C`. 

When running tests in JetBrains Rider, failing to find the actual runtime config file leads to loading the `ReSharperTestRunner.runtimeconfig.json` file whose tfm is `netcoreapp3.0`:

```json
{
  "runtimeOptions": {
    "tfm": "netcoreapp3.0",
    "framework": {
      "name": "Microsoft.NETCore.App",
      "version": "3.0.0"
    }
  }
}
```

Running on the wrong framework version eventually leads to the following exception:
> Xunit.Sdk.XunitException
> 
```
Function exit code failed with exit code: 134
Unhandled exception: System.IO.FileLoadException: Could not load file or assembly 'System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The located assembly's manifest definition does not match the assembly reference. (0x80131040)
File name: 'System.Runtime, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
   at System.Reflection.RuntimeAssembly.GetType(QCallAssembly assembly, String name, Boolean throwOnError, Boolean ignoreCase, ObjectHandleOnStack type, ObjectHandleOnStack keepAlive, ObjectHandleOnStack assemblyLoadContext)
   at System.Reflection.RuntimeAssembly.GetType(String name, Boolean throwOnError, Boolean ignoreCase)
   at System.Reflection.Assembly.GetType(String name)
   at Tmds.Utils.ExecFunction.Program.Main(String[] args) in Tmds.ExecFunction/src/Tmds.ExecFunction/ExecFunction.Program.cs:line 73
```

Note: I stumbled on this issue when running the [coverlet](https://github.com/coverlet-coverage/coverlet/) tests.