### PR TITLE
Fix debugging the child process in VS.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,8 +1,10 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="EnvDTE" Version="17.8.37221 " />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
+
+    <!-- !! Also update EnvDTEVersion in Tmds.ExecFunction.targets. -->
+    <PackageVersion Include="EnvDTE" Version="17.8.37221" />
   </ItemGroup>
 </Project>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>0.7.0</VersionPrefix>
+    <VersionPrefix>0.7.1</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Execute a function in a separate process</Description>
     <Authors>Tom Deseyn</Authors>

--- a/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
+++ b/src/Tmds.ExecFunction/Tmds.ExecFunction.targets
@@ -1,9 +1,23 @@
 ﻿<Project>
-  <ItemGroup Condition="'$(Configuration)' == 'Debug'">
-    <PackageReference Include="EnvDTE" />
+  <PropertyGroup>
+    <EnableExecFunctionVsDebugging Condition="'$(EnableExecFunctionVsDebugging)' == '' And '$(Configuration)' == 'Debug'">true</EnableExecFunctionVsDebugging>
+    <EnvDTEVersion Condition="'$(EnvDTEVersion)' == ''">17.8.37221</EnvDTEVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableExecFunctionVsDebugging)' == 'true' And '$(ManagePackageVersionsCentrally)' != 'true'">
+    <PackageReference Include="EnvDTE" Exclude="@(PackageReference)" Version="$(EnvDTEVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableExecFunctionVsDebugging)' == 'true' And '$(ManagePackageVersionsCentrally)' == 'true'">
+    <PackageVersion Include="EnvDTE" Exclude="@(PackageVersion)" Version="$(EnvDTEVersion)" />
+    <PackageReference Include="EnvDTE" Exclude="@(PackageReference)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(EnableExecFunctionVsDebugging)' == 'true'">
     <VsDebuggerFile Include="$(MSBuildThisFileDirectory)\..\tools\any\vsdebugger\**\*" />
   </ItemGroup>
-  <Target Name="CopyVsDebuggerFileOnBuild" Condition="'$(Configuration)' == 'Debug'" BeforeTargets="Build">
+
+  <Target Name="CopyVsDebuggerFileOnBuild" Condition="'$(EnableExecFunctionVsDebugging)' == 'true'" BeforeTargets="Build">
     <Copy SourceFiles="@(VsDebuggerFile)" DestinationFolder="$(TargetDir)\" />
   </Target>
 </Project>


### PR DESCRIPTION
Using NuGet central package management unintentionally lead to the removal of the EnvDTE Version attributes in the .targets file.

Regressed in https://github.com/tmds/Tmds.ExecFunction/pull/24.